### PR TITLE
논평 상세 보기 화면, 스와이프시 이전 / 다음 논평으로 넘어가는 액션 추가 ( +useSwipe)

### DIFF
--- a/components/common/messageBox/index.tsx
+++ b/components/common/messageBox/index.tsx
@@ -19,16 +19,20 @@ export function CommonMessageBox({ children, style = {} }: MessageBoxProps) {
   );
 }
 
-export function PositiveMessageBox({ children, style = {} }: MessageBoxProps) {
+export function DefaultMessageBox({ children, style = {} }: MessageBoxProps) {
   return (
-    <PositiveWrapper
+    <DefaultWrapper
       style={{
         ...style,
       }}
     >
       {children}
-    </PositiveWrapper>
+    </DefaultWrapper>
   );
+}
+
+export function PositiveMessageBox({ children, style }: MessageBoxProps) {
+  return <PositiveWrapper style={{ ...style }}>{children}</PositiveWrapper>;
 }
 
 export function NegativeMessageBox({ children, style }: MessageBoxProps) {
@@ -68,10 +72,17 @@ const CommonWrapper = styled(Wrapper)`
   box-shadow: 0px 0px 10px -5px ${({ theme }) => RGB(theme.colors.gray700)};
 `;
 
-const PositiveWrapper = styled(Wrapper)`
+const DefaultWrapper = styled(Wrapper)`
   background-color: ${({ theme }) => RGBA(theme.colors.gray700, 1)};
   border: none;
   color: white;
+`;
+
+const PositiveWrapper = styled(Wrapper)`
+  background-color: ${({ theme }) => theme.colors.yvote03};
+  border: none;
+  color: white;
+  font-weight: 500;
 `;
 
 const NegativeWrapper = styled(Wrapper)``;

--- a/components/keywords/searchBox/index.tsx
+++ b/components/keywords/searchBox/index.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 
 import styled from 'styled-components';
 
-import { PositiveMessageBox } from '@components/common/messageBox';
+import { DefaultMessageBox } from '@components/common/messageBox';
 import KeywordRepository from '@repositories/keywords';
 import { useToastMessage } from '@utils/hook/useToastMessage';
 import { Keyword } from '@utils/interface/keywords';
@@ -89,9 +89,9 @@ export default function SearchBox() {
       e.preventDefault();
       if (!arrObjIncludeProp(keylist, 'keyword', searchWord)) {
         show(
-          <PositiveMessageBox>
+          <DefaultMessageBox>
             <p>{'존재하지 않는 키워드에요.'}</p>
-          </PositiveMessageBox>,
+          </DefaultMessageBox>,
           2000,
         );
         return;

--- a/components/news/commentModal/commentBodyCommon.tsx
+++ b/components/news/commentModal/commentBodyCommon.tsx
@@ -1,4 +1,6 @@
+import { useDevice } from '@/utils/hook/useDevice';
 import { RowSwipeCature } from '@/utils/hook/useSwipe';
+import { Device } from '@/utils/interface/common';
 import { getSessionItem, saveSessionItem } from '@/utils/tools/session';
 import { TextButton } from '@components/common/commonStyles';
 import IsShow from '@components/common/isShow';
@@ -25,6 +27,7 @@ export default function CommentBodyCommon({
   commentType: commentType;
   close: () => void;
 }) {
+  const device = useDevice();
   const { show: showToastMessage } = useToastMessage();
   const { page, curComments, isRequesting, getPageBefore, getPageAfter } = useFetchNewsComment(
     id,
@@ -64,18 +67,20 @@ export default function CommentBodyCommon({
                   setCurComment(comment);
                   moveToScrollHeight(0);
 
-                  const item = getSessionItem('commentSwipeToast');
+                  if (device === Device.mobile) {
+                    const item = getSessionItem('commentSwipeToast');
 
-                  if (item) return;
-                  saveSessionItem('commentSwipeToast', 'true');
+                    if (item) return;
+                    saveSessionItem('commentSwipeToast', 'true');
 
-                  showToastMessage(
-                    <CommonMessageBox>좌우로 밀어서 논평을 넘겨볼 수 있어요.</CommonMessageBox>,
-                    2500,
-                    {
-                      direction: 'bottom',
-                    },
-                  );
+                    showToastMessage(
+                      <CommonMessageBox>좌우로 밀어서 논평을 넘겨볼 수 있어요.</CommonMessageBox>,
+                      2500,
+                      {
+                        direction: 'bottom',
+                      },
+                    );
+                  }
                 }}
               />
             ) : (

--- a/components/news/commentModal/commentBodyCommon.tsx
+++ b/components/news/commentModal/commentBodyCommon.tsx
@@ -1,3 +1,4 @@
+import { RowSwipeCature } from '@/utils/hook/useSwipe';
 import { TextButton } from '@components/common/commonStyles';
 import IsShow from '@components/common/isShow';
 import LoadingCommon from '@components/common/loading';
@@ -109,12 +110,32 @@ export default function CommentBodyCommon({
                   maxScrollHeight={maxScrollHeight}
                   moveToScrollHeight={moveToScrollHeight}
                 />
-                <CommentBodyExplain
-                  id={id}
-                  title={curComment.title}
-                  explain={curComment.comment}
-                  date={curComment.date}
-                />
+                <RowSwipeCature
+                  threshold={10}
+                  onLeftSwipe={() => {
+                    showCommentEndMessage(
+                      <PositiveMessageBox>
+                        <p>왼쪽</p>
+                      </PositiveMessageBox>,
+                      2000,
+                    );
+                  }}
+                  onRightSwipe={() => {
+                    showCommentEndMessage(
+                      <PositiveMessageBox>
+                        <p>오른쪽</p>
+                      </PositiveMessageBox>,
+                      2000,
+                    );
+                  }}
+                >
+                  <CommentBodyExplain
+                    id={id}
+                    title={curComment.title}
+                    explain={curComment.comment}
+                    date={curComment.date}
+                  />
+                </RowSwipeCature>
               </>
             )}
           </ScrollWrapper>

--- a/components/news/commentModal/commentBodyCommon.tsx
+++ b/components/news/commentModal/commentBodyCommon.tsx
@@ -1,8 +1,9 @@
 import { RowSwipeCature } from '@/utils/hook/useSwipe';
+import { getSessionItem, saveSessionItem } from '@/utils/tools/session';
 import { TextButton } from '@components/common/commonStyles';
 import IsShow from '@components/common/isShow';
 import LoadingCommon from '@components/common/loading';
-import { PositiveMessageBox } from '@components/common/messageBox';
+import { CommonMessageBox, DefaultMessageBox } from '@components/common/messageBox';
 import { useToastMessage } from '@utils/hook/useToastMessage';
 import { Comment, commentType } from '@utils/interface/news';
 import { useEffect, useState } from 'react';
@@ -62,6 +63,19 @@ export default function CommentBodyCommon({
                   saveScrollHeight();
                   setCurComment(comment);
                   moveToScrollHeight(0);
+
+                  const item = getSessionItem('commentSwipeToast');
+
+                  if (item) return;
+                  saveSessionItem('commentSwipeToast', 'true');
+
+                  showToastMessage(
+                    <CommonMessageBox>좌우로 밀어서 논평을 넘겨볼 수 있어요.</CommonMessageBox>,
+                    2500,
+                    {
+                      direction: 'bottom',
+                    },
+                  );
                 }}
               />
             ) : (
@@ -87,9 +101,9 @@ export default function CommentBodyCommon({
                         moveToScrollHeight(0);
                       } else {
                         showToastMessage(
-                          <PositiveMessageBox>
+                          <DefaultMessageBox>
                             <p>가장 최신 논평입니다!</p>
-                          </PositiveMessageBox>,
+                          </DefaultMessageBox>,
                           2000,
                         );
                       }
@@ -109,9 +123,9 @@ export default function CommentBodyCommon({
                         moveToScrollHeight(0);
                       } else {
                         showToastMessage(
-                          <PositiveMessageBox>
+                          <DefaultMessageBox>
                             <p>준비된 평론들을 모두 확인했어요</p>
-                          </PositiveMessageBox>,
+                          </DefaultMessageBox>,
                           2000,
                         );
                       }
@@ -160,9 +174,9 @@ export default function CommentBodyCommon({
                   moveToScrollHeight(0);
                 } else {
                   showToastMessage(
-                    <PositiveMessageBox>
+                    <DefaultMessageBox>
                       <p>준비된 평론들을 모두 확인했어요</p>
-                    </PositiveMessageBox>,
+                    </DefaultMessageBox>,
                     2000,
                   );
                 }

--- a/components/news/commentModal/commentBodyExplain.tsx
+++ b/components/news/commentModal/commentBodyExplain.tsx
@@ -100,10 +100,14 @@ const ContentBody = styled.div`
   font-size: 15px;
 `;
 
-const ContentLine = styled.div`
+const ContentLine = styled.p`
+  margin: 0;
+  padding: 0;
+
   color: black;
   margin-bottom: 0.5rem;
   min-height: 10px;
+  cursor: text;
 `;
 
 const DateButtonWrapper = styled.div`
@@ -141,4 +145,16 @@ const GrokButton = styled.button`
 
 const IsFetching = styled(Backdrop)`
   backdrop-filter: opacity(100%);
+`;
+
+const Blink = styled.div`
+  @keyframes back-blink {
+    0% {
+      opacity: 0.4;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+  animation: back-blink 0.4s ease-in-out forwards;
 `;

--- a/components/news/commentModal/commentModal.hook.ts
+++ b/components/news/commentModal/commentModal.hook.ts
@@ -57,27 +57,6 @@ export const useFetchNewsComment = (id: number, comment: commentType | null) => 
   };
 };
 
-export const useCurComment = () => {
-  const [curComment, setCurComment] = useState<Comment | null>(null);
-
-  const showCurComment = useCallback(
-    (comment: Comment) => {
-      setCurComment(comment);
-    },
-    [setCurComment],
-  );
-
-  const closeCurComment = useCallback(() => {
-    setCurComment(null);
-  }, [setCurComment]);
-
-  return {
-    curComment,
-    showCurComment,
-    closeCurComment,
-  };
-};
-
 export const useListScrollheight = (ref?: RefObject<HTMLDivElement>) => {
   let target = useRef<HTMLDivElement>(null);
   if (ref) target = ref;

--- a/components/news/newsLIst/index.tsx
+++ b/components/news/newsLIst/index.tsx
@@ -1,7 +1,7 @@
 import { Column, CommonLayoutBox } from '@components/common/commonStyles';
 import IsShow from '@components/common/isShow';
 import LoadingCommon from '@components/common/loading';
-import { PositiveMessageBox } from '@components/common/messageBox';
+import { DefaultMessageBox } from '@components/common/messageBox';
 import { useToastMessage } from '@utils/hook/useToastMessage';
 import { Preview } from '@utils/interface/news';
 import { useCallback } from 'react';
@@ -34,9 +34,9 @@ export default function NewsList({
     const res = await fetchPreviews();
     if (!res) {
       showToastMessage(
-        <PositiveMessageBox>
+        <DefaultMessageBox>
           <p>{'와이보트가 준비한 소식을 모두 받아왔어요'}</p>
-        </PositiveMessageBox>,
+        </DefaultMessageBox>,
         2000,
       );
     }

--- a/components/news/newsListSection/index.tsx
+++ b/components/news/newsListSection/index.tsx
@@ -1,5 +1,5 @@
 import { Column, CommonLayoutBox } from '@/components/common/commonStyles';
-import { PositiveMessageBox } from '@/components/common/messageBox';
+import { DefaultMessageBox } from '@/components/common/messageBox';
 import { getNewsPreviewsQueryOption } from '@/queryOption/getNewsPreviews';
 import { useToastMessage } from '@/utils/hook/useToastMessage';
 import { getSessionItem, saveSessionItem } from '@/utils/tools/session';
@@ -86,17 +86,17 @@ export default function NewsListSection({
             const lastPage = data?.pages[data.pages.length - 1];
             if (lastPage === undefined || lastPage.length === 0) {
               showToastMessage(
-                <PositiveMessageBox>
+                <DefaultMessageBox>
                   <p>{'와이보트가 준비한 소식을 모두 받아왔어요'}</p>
-                </PositiveMessageBox>,
+                </DefaultMessageBox>,
                 2000,
               );
             }
           } catch (e) {
             showToastMessage(
-              <PositiveMessageBox>
+              <DefaultMessageBox>
                 <p>{'다시 시도해 주세요.'}</p>
-              </PositiveMessageBox>,
+              </DefaultMessageBox>,
               2000,
             );
           }

--- a/components/news/newsListSection/index.tsx
+++ b/components/news/newsListSection/index.tsx
@@ -126,6 +126,7 @@ function getCachedInfo() {
     scroll: 0,
     page: 0,
   };
+  if (typeof window === 'undefined') return defaultCacheInfo;
   const key = (history?.state?.key as string) ?? null;
   if (!key) return defaultCacheInfo;
   const item = getSessionItem(key);
@@ -135,6 +136,7 @@ function getCachedInfo() {
 }
 
 function saveCachedInfo(cacheInfo: CacheInfo) {
+  if (typeof window === 'undefined') return;
   const key = (history?.state?.key as string) ?? null;
   if (!key) return;
   saveSessionItem(key, cacheInfo);

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "prettier": "^2.8.7",
     "typescript": "^5.0.3"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }

--- a/pages/analyze/index.tsx
+++ b/pages/analyze/index.tsx
@@ -1,10 +1,10 @@
 import Questionnaire from '@components/analyze/questionnaire';
 import Result, { ResultAnswers } from '@components/analyze/result';
 import HeadMeta from '@components/common/HeadMeta';
-import { PositiveMessageBox } from '@components/common/messageBox';
+import { DefaultMessageBox } from '@components/common/messageBox';
 import { useMount } from '@utils/hook/useMount';
 import { useToastMessage } from '@utils/hook/useToastMessage';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 const metaTagsProps = {
@@ -25,7 +25,7 @@ export default function Analyze() {
   const { show } = useToastMessage();
 
   useMount(() => {
-    show(<PositiveMessageBox>현재 준비 중인 서비스입니다.</PositiveMessageBox>, 2000);
+    show(<DefaultMessageBox>현재 준비 중인 서비스입니다.</DefaultMessageBox>, 2000);
   });
 
   return (

--- a/utils/hook/useSwipe.tsx
+++ b/utils/hook/useSwipe.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useRef, useState } from 'react';
+
+export type Axis = 'x' | 'y' | 'both';
+export type Direction = 'left' | 'right' | 'up' | 'down' | null;
+
+export type Options = {
+  threshold?: number;
+  axis?: Axis;
+  onStart?: (e: React.PointerEvent) => void;
+  onEnd?: (dir: Direction, dx: number, dy: number) => void;
+};
+
+export function useSwipe(opts: Options = {}) {
+  const { threshold = 16, axis = 'both', onStart, onEnd } = opts;
+
+  const idRef = useRef<number | null>(null);
+  const startX = useRef(0);
+  const startY = useRef(0);
+
+  const lastX = useRef(0);
+  const lastY = useRef(0);
+
+  const [state, setState] = useState({
+    isSwiping: false,
+    dx: 0,
+    dy: 0,
+    direction: null as Direction,
+  });
+
+  const passed = (dx: number, dy: number) => {
+    const adx = Math.abs(dx);
+    const ady = Math.abs(dy);
+    if (axis === 'x') return adx >= threshold;
+    if (axis === 'y') return ady >= threshold;
+    return Math.max(adx, ady) >= threshold;
+  };
+
+  const dir = (dx: number, dy: number): Direction => {
+    const adx = Math.abs(dx);
+    const ady = Math.abs(dy);
+    if (axis === 'x') return dx < 0 ? 'left' : 'right';
+    if (axis === 'y') return dy < 0 ? 'up' : 'down';
+    return adx >= ady ? (dx < 0 ? 'left' : 'right') : dy < 0 ? 'up' : 'down';
+  };
+  const onPointerMove: React.PointerEventHandler = (e) => {
+    if (idRef.current !== e.pointerId) return;
+    lastX.current = e.clientX;
+    lastY.current = e.clientY;
+  };
+  const onPointerDown: React.PointerEventHandler = (e) => {
+    if (!e.isPrimary) return;
+    idRef.current = e.pointerId;
+    startX.current = e.clientX;
+    startY.current = e.clientY;
+
+    setState({ isSwiping: true, dx: 0, dy: 0, direction: null });
+    onStart?.(e);
+    try {
+      (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+    } catch {}
+  };
+
+  const finish = useCallback(
+    (e: React.PointerEvent) => {
+      if (idRef.current !== e.pointerId) return;
+
+      const dx = (lastX.current ?? e.clientX) - startX.current;
+      const dy = (lastY.current ?? e.clientY) - startY.current;
+      const d = passed(dx, dy) ? dir(dx, dy) : null;
+      setState({ isSwiping: false, dx, dy, direction: d });
+      onEnd?.(d, dx, dy);
+      idRef.current = null;
+    },
+    [onEnd],
+  );
+
+  return {
+    bind: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: finish,
+      onPointerCancel: finish,
+    },
+    state,
+  } as const;
+}
+
+type RowSwipeCaptureProps = React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>> & {
+  threshold?: number;
+  onLeftSwipe: () => void;
+  onRightSwipe: () => void;
+};
+
+export function RowSwipeCature({
+  children,
+  threshold = 10,
+  onLeftSwipe,
+  onRightSwipe,
+  ...others
+}: RowSwipeCaptureProps) {
+  const { bind } = useSwipe({
+    axis: 'x',
+    threshold,
+    onEnd: (dir) => {
+      if (dir === 'left') onLeftSwipe();
+      if (dir === 'right') onRightSwipe();
+    },
+  });
+
+  return (
+    <div {...others} {...bind}>
+      {children}
+    </div>
+  );
+}

--- a/utils/hook/useSwipe.tsx
+++ b/utils/hook/useSwipe.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useRef, useState } from 'react';
+import styled from 'styled-components';
 
 export type Axis = 'x' | 'y' | 'both';
-export type Direction = 'left' | 'right' | 'up' | 'down' | null;
+export type Direction = 'left' | 'right' | 'up' | 'down';
 
 export type Options = {
   threshold?: number;
   axis?: Axis;
   onStart?: (e: React.PointerEvent) => void;
-  onEnd?: (dir: Direction, dx: number, dy: number) => void;
+  onEnd?: (dir: Direction | null, dx: number, dy: number) => void;
 };
 
 export function useSwipe(opts: Options = {}) {
@@ -24,7 +25,7 @@ export function useSwipe(opts: Options = {}) {
     isSwiping: false,
     dx: 0,
     dy: 0,
-    direction: null as Direction,
+    direction: null as Direction | null,
   });
 
   const passed = (dx: number, dy: number) => {
@@ -38,17 +39,23 @@ export function useSwipe(opts: Options = {}) {
   const dir = (dx: number, dy: number): Direction => {
     const adx = Math.abs(dx);
     const ady = Math.abs(dy);
-    if (axis === 'x') return dx < 0 ? 'left' : 'right';
-    if (axis === 'y') return dy < 0 ? 'up' : 'down';
-    return adx >= ady ? (dx < 0 ? 'left' : 'right') : dy < 0 ? 'up' : 'down';
+    if (axis === 'x') return dx < 0 ? 'right' : 'left';
+    if (axis === 'y') return dy < 0 ? 'down' : 'up';
+    return adx >= ady ? (dx < 0 ? 'right' : 'left') : dy < 0 ? 'down' : 'up';
   };
-  const onPointerMove: React.PointerEventHandler = (e) => {
-    if (idRef.current !== e.pointerId) return;
-    lastX.current = e.clientX;
-    lastY.current = e.clientY;
+
+  const initialize = () => {
+    setState({
+      isSwiping: false,
+      dx: 0,
+      dy: 0,
+      direction: null,
+    });
   };
+
   const onPointerDown: React.PointerEventHandler = (e) => {
     if (!e.isPrimary) return;
+
     idRef.current = e.pointerId;
     startX.current = e.clientX;
     startY.current = e.clientY;
@@ -60,15 +67,31 @@ export function useSwipe(opts: Options = {}) {
     } catch {}
   };
 
+  const onPointerMove: React.PointerEventHandler = (e) => {
+    if (idRef.current !== e.pointerId || !state.isSwiping) return;
+    lastX.current = e.clientX;
+    lastY.current = e.clientY;
+  };
+
   const finish = useCallback(
     (e: React.PointerEvent) => {
-      if (idRef.current !== e.pointerId) return;
+      if (idRef.current !== e.pointerId || !state.isSwiping) return;
+
+      if (e.pointerType === 'mouse') {
+        const sel = window.getSelection?.();
+        if (sel && !sel.isCollapsed) {
+          initialize();
+          return;
+        }
+      }
 
       const dx = (lastX.current ?? e.clientX) - startX.current;
       const dy = (lastY.current ?? e.clientY) - startY.current;
       const d = passed(dx, dy) ? dir(dx, dy) : null;
+
       setState({ isSwiping: false, dx, dy, direction: d });
       onEnd?.(d, dx, dy);
+      initialize();
       idRef.current = null;
     },
     [onEnd],
@@ -108,8 +131,17 @@ export function RowSwipeCature({
   });
 
   return (
-    <div {...others} {...bind}>
+    <SwipeWrapper {...others} {...bind}>
       {children}
-    </div>
+    </SwipeWrapper>
   );
 }
+
+const SwipeWrapper = styled.div`
+  min-height: 100%;
+
+  touch-action: pan-y;
+  &:hover {
+    cursor: grab;
+  }
+`;

--- a/utils/hook/useToastMessage/toastMessageProvider.tsx
+++ b/utils/hook/useToastMessage/toastMessageProvider.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, ReactNode, useState } from 'react';
 import styled from 'styled-components';
-import { ToastMessageContext } from './useToastMessage';
+import { ToastDirection, ToastMessageContext } from './useToastMessage';
 
 let id = 0;
 
@@ -8,14 +8,29 @@ interface Node {
   id: number;
   element: ReactNode;
   is: boolean;
+  direction: ToastDirection;
 }
 
 export function ToastMessageProvider({ children, ...others }: PropsWithChildren) {
   const [toastMessages, setToastMessages] = useState<Node[]>([]);
 
-  const show = (ele: ReactNode, time: number) => {
+  const show = (
+    ele: ReactNode,
+    time: number,
+    option?: {
+      direction?: ToastDirection;
+    },
+  ) => {
     let nodeId = (id += 1);
-    setToastMessages([...toastMessages, { id: nodeId, element: ele, is: true }]);
+
+    console.log('option : ', option);
+
+    const direction = option?.direction ?? 'top';
+    console.log(direction);
+    setToastMessages([
+      ...toastMessages,
+      { id: nodeId, element: ele, is: true, direction: direction },
+    ]);
     setTimeout(() => {
       close(nodeId);
     }, time);
@@ -43,11 +58,21 @@ export function ToastMessageProvider({ children, ...others }: PropsWithChildren)
   return (
     <ToastMessageContext.Provider value={{ show }} {...others}>
       {children}
-      {toastMessages.map((node) => (
-        <ToastMessage key={node.id} is={node.is}>
-          {node.element}
-        </ToastMessage>
-      ))}
+      {toastMessages.map((node) => {
+        if (node.direction === 'top') {
+          return (
+            <ToastMessageTop key={node.id} $isShow={node.is}>
+              {node.element}
+            </ToastMessageTop>
+          );
+        } else {
+          return (
+            <ToastMessageDown key={node.id} $isShow={node.is}>
+              {node.element}
+            </ToastMessageDown>
+          );
+        }
+      })}
     </ToastMessageContext.Provider>
   );
 }
@@ -70,12 +95,15 @@ const ToastMessageWrapper = styled.div<ToastMessageWrapperProps>`
   left: 50%;
   transform: translate(-50%, 0%);
   z-index: 99999;
+`;
+
+const ToastMessageTop = styled(ToastMessageWrapper)`
   animation: ${({ $isShow }) =>
     $isShow
-      ? 'showAnimation 0.3s ease-in-out forwards'
-      : 'closeAnimation 0.3s ease-in-out forwards'};
+      ? 'showTopAnimation 0.3s ease-in-out forwards'
+      : 'closeTopAnimation 0.3s ease-in-out forwards'};
 
-  @keyframes showAnimation {
+  @keyframes showTopAnimation {
     0% {
       opacity: 0;
       top: 9%;
@@ -86,13 +114,42 @@ const ToastMessageWrapper = styled.div<ToastMessageWrapperProps>`
     }
   }
 
-  @keyframes closeAnimation {
+  @keyframes closeTopAnimation {
     0% {
       opacity: 1;
       top: 12%;
     }
     100% {
       top: 9%;
+      opacity: 0;
+    }
+  }
+`;
+
+const ToastMessageDown = styled(ToastMessageWrapper)`
+  animation: ${({ $isShow }) =>
+    $isShow
+      ? 'showBottomAnimation 0.3s ease-in-out forwards'
+      : 'closeBottomAnimation 0.3s ease-in-out forwards'};
+
+  @keyframes showBottomAnimation {
+    0% {
+      opacity: 0;
+      bottom: 9%;
+    }
+    100% {
+      opacity: 1;
+      bottom: 12%;
+    }
+  }
+
+  @keyframes closeBottomAnimation {
+    0% {
+      opacity: 1;
+      bottom: 12%;
+    }
+    100% {
+      bottom: 9%;
       opacity: 0;
     }
   }

--- a/utils/hook/useToastMessage/useToastMessage.tsx
+++ b/utils/hook/useToastMessage/useToastMessage.tsx
@@ -1,7 +1,15 @@
 import { ReactNode, createContext, useContext } from 'react';
 
+export type ToastDirection = 'top' | 'bottom';
+
 export interface ToastMessageContextProp {
-  show: (comp: ReactNode, time: number) => number;
+  show: (
+    comp: ReactNode,
+    time: number,
+    option?: {
+      direction?: ToastDirection;
+    },
+  ) => number;
 }
 
 export const ToastMessageContext = createContext<ToastMessageContextProp | null>(null);


### PR DESCRIPTION
#️⃣ 히스토리
- 논평 상세 보기 화면에서 다른 논평 진입 목적 시 논평 목록 재 진입 후 넘어갔어야 함.
- 불편함을 해소하고자 스와이프 액션으로 넘어가기 추가
- ** 이슈가 있는 점은 피시에서는 스와이프 액션이 편한 ux 가 아님  ( 텍스트 드래그, 스크롤 등과 맞물림)
- ** 피시에서는 위 스와이프 기능을 제어하고, 우선은 모바일에서 기능 제공 ( 피시에서는 버튼 등으로 후에 처리 예정)

#️⃣ 작업 내용

- useSwipe 훅 + SwipeCapture 컴포넌트 개발 ( SwipeCapture 컴포넌트를 통해 useSwipe 를 부르지 않고 컴포넌트를 wrapping 하여서 swipe 액션 관리 가능 )
- 처음 상세화면 진입 시 스와이프가 가능함을 알리기 위한 toastMessage 띄움
- left / right 액션에 대해 이전 / 다음 논평 바꿔치기 & 존재 여부 판단 후 적절히 토스트 메세지 띄워줌

#️⃣ 주요 변경 소스
components/news/commentModal/commentBodyCommon.tsx
utils/hook/useSwipe.tsx