### PR TITLE
평론 화면 이전, 다음 자료 보기 버튼 추가

### DIFF
--- a/components/common/figure/buttons/index.tsx
+++ b/components/common/figure/buttons/index.tsx
@@ -3,12 +3,12 @@ import styled from 'styled-components';
 
 interface LeftButtonProps {
   curView: number;
-  viewToLeft: () => void;
+  viewToLeft: () => unknown;
 }
 
 interface RightButtonProps {
   curView: number;
-  viewToRight: () => void;
+  viewToRight: () => unknown;
   lastPage: number;
 }
 

--- a/utils/hook/useSwipe.tsx
+++ b/utils/hook/useSwipe.tsx
@@ -12,7 +12,7 @@ export type Options = {
 };
 
 export function useSwipe(opts: Options = { axis: 'x' }) {
-  const { threshold = 16, axis = 'both', onStart, onEnd } = opts;
+  const { threshold = 16, axis = 'x', onStart, onEnd } = opts;
 
   const idRef = useRef<number | null>(null);
 


### PR DESCRIPTION
#️⃣ 히스토리
> 논평 상세 보기 화면 스와이프 추가로 이전, 다음 논평 조회 가능
> 스와이프 기능 특성상 모바일에만 추가해두었고, pc 에서는 위 기능 활용이 불가
> 추가로 모바일 진입 시 토스트 메세지를 통해 스와이프가 가능함을 알려주지만, 다른 유도가 부족한 상황
- 좌우 이동 버튼 추가로 피시 기능 개선 & 모바일 ux 개선

#️⃣ 작업 내용
- 논평 상세보기 화면 좌/우 arrow 버튼 추가
- 이전/다음 논평 보기 함수 분리

#️⃣ 주요 변경 소스
components/news/commentModal/commentBodyCommon.tsx